### PR TITLE
recessive/dominant analysis with bgens

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -353,8 +353,8 @@ setminMAFforGRM <- function(minMAFforGRM) {
     invisible(.Call('_SAIGE_setminMAFforGRM', PACKAGE = 'SAIGE', minMAFforGRM))
 }
 
-setgenoTest_bgenDosage <- function(filename, index_filename, ranges_to_include, ranges_to_exclude, ids_to_include, ids_to_exclude) {
-    .Call('_SAIGE_setgenoTest_bgenDosage', PACKAGE = 'SAIGE', filename, index_filename, ranges_to_include, ranges_to_exclude, ids_to_include, ids_to_exclude)
+setgenoTest_bgenDosage <- function(filename, index_filename, ranges_to_include, ranges_to_exclude, ids_to_include, ids_to_exclude, analysis_type) {
+    .Call('_SAIGE_setgenoTest_bgenDosage', PACKAGE = 'SAIGE', filename, index_filename, ranges_to_include, ranges_to_exclude, ids_to_include, ids_to_exclude, analysis_type)
 }
 
 getDosage_inner_bgen_withquery <- function() {

--- a/R/SAIGE_SPATest.R
+++ b/R/SAIGE_SPATest.R
@@ -92,8 +92,13 @@ SPAGMMATtest = function(dosageFile = "",
 		 cateVarRatioMinMACVecExclude=c(0.5,1.5,2.5,3.5,4.5,5.5,10.5,20.5), 
 		 cateVarRatioMaxMACVecInclude=c(1.5,2.5,3.5,4.5,5.5,10.5,20.5),
 		 singleGClambda = 1,
-		 IsOutputPvalueNAinGroupTestforBinary = FALSE){
-#		 adjustCCratioinGroupTest=FALSE){
+		 IsOutputPvalueNAinGroupTestforBinary = FALSE,
+		 analysisType = "additive"){
+#		 adjustCCratioinGroupTest=FALSE,
+
+  if (analysisType != "additive" & analysisType != "recessive" & analysisType != "dominant") {
+    stop("Unknown analysis type (supported 'additive', 'recessive', and 'dominant': ", analysisType)
+  }
 
   # if group file is specified, the region-based test will be performed, otherwise, the single-variant assoc test will be performed. 
   adjustCCratioinGroupTest=FALSE
@@ -571,7 +576,7 @@ SPAGMMATtest = function(dosageFile = "",
         ranges_to_include = data.frame(chromosome = NULL, start = NULL, end = NULL)
       }
 
-      Mtest = setgenoTest_bgenDosage(bgenFile,bgenFileIndex, ranges_to_exclude = ranges_to_exclude, ranges_to_include = ranges_to_include, ids_to_exclude= ids_to_exclude, ids_to_include=ids_to_include)
+      Mtest = setgenoTest_bgenDosage(bgenFile,bgenFileIndex, ranges_to_exclude = ranges_to_exclude, ranges_to_include = ranges_to_include, ids_to_exclude= ids_to_exclude, ids_to_include=ids_to_include, analysis_type=analysisType)
       if(Mtest == 0){
         isVariant = FALSE
         stop("ERROR! Failed to open ", bgenFile, "\n")

--- a/extdata/install_packages.R
+++ b/extdata/install_packages.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 #install required R packages, from Finnge/SAIGE-IT
 
-req_packages <- c("R.utils", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "SKAT","MetaSKAT")
+req_packages <- c("R.utils", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "qqman", "SKAT","MetaSKAT")
 for (pack in req_packages) {
     if(!require(pack,character.only = TRUE)) {
         install.packages(pack, repos = "http://cran.us.r-project.org")

--- a/extdata/step2_SPAtests.R
+++ b/extdata/step2_SPAtests.R
@@ -94,7 +94,10 @@ option_list <- list(
   make_option("--singleGClambda",type="numeric", default=1,
     help="GC lambda values that can be used to adjust the gene-based tests results. This value is usually estimated based on the single-variant assoc test results. [default=1]"),
   make_option("--IsOutputPvalueNAinGroupTestforBinary", type="logical",default=FALSE,
-    help="whether to output p value if not account for case-control imbalance when performing group test (only for binary traits). [default=FALSE]")	
+    help="whether to output p value if not account for case-control imbalance when performing group test (only for binary traits). [default=FALSE]"),
+  make_option("--analysisType", type="character", default='additive',
+    help="'additive' (default), 'recessive' (het probability set to 0), or 'dominant' (hom alt probability set to 0)")
+
 )
 
 parser <- OptionParser(usage="%prog [options]", option_list=option_list)
@@ -156,7 +159,8 @@ SPAGMMATtest(dosageFile=opt$dosageFile,
              cateVarRatioMinMACVecExclude=cateVarRatioMinMACVecExclude,
              cateVarRatioMaxMACVecInclude=cateVarRatioMaxMACVecInclude,
 	     singleGClambda=opt$singleGClambda,
-		IsOutputPvalueNAinGroupTestforBinary=opt$IsOutputPvalueNAinGroupTestforBinary
+		IsOutputPvalueNAinGroupTestforBinary=opt$IsOutputPvalueNAinGroupTestforBinary,
+ 	        analysisType = opt$analysisType
 )
 
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1098,8 +1098,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // setgenoTest_bgenDosage
-int setgenoTest_bgenDosage(std::string& filename, std::string& index_filename, Rcpp::DataFrame& ranges_to_include, Rcpp::DataFrame& ranges_to_exclude, std::vector< std::string > const& ids_to_include, std::vector< std::string > const& ids_to_exclude);
-RcppExport SEXP _SAIGE_setgenoTest_bgenDosage(SEXP filenameSEXP, SEXP index_filenameSEXP, SEXP ranges_to_includeSEXP, SEXP ranges_to_excludeSEXP, SEXP ids_to_includeSEXP, SEXP ids_to_excludeSEXP) {
+int setgenoTest_bgenDosage(std::string& filename, std::string& index_filename, Rcpp::DataFrame& ranges_to_include, Rcpp::DataFrame& ranges_to_exclude, std::vector< std::string > const& ids_to_include, std::vector< std::string > const& ids_to_exclude, std::string& analysis_type);
+RcppExport SEXP _SAIGE_setgenoTest_bgenDosage(SEXP filenameSEXP, SEXP index_filenameSEXP, SEXP ranges_to_includeSEXP, SEXP ranges_to_excludeSEXP, SEXP ids_to_includeSEXP, SEXP ids_to_excludeSEXP, SEXP analysis_typeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1109,7 +1109,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::DataFrame& >::type ranges_to_exclude(ranges_to_excludeSEXP);
     Rcpp::traits::input_parameter< std::vector< std::string > const& >::type ids_to_include(ids_to_includeSEXP);
     Rcpp::traits::input_parameter< std::vector< std::string > const& >::type ids_to_exclude(ids_to_excludeSEXP);
-    rcpp_result_gen = Rcpp::wrap(setgenoTest_bgenDosage(filename, index_filename, ranges_to_include, ranges_to_exclude, ids_to_include, ids_to_exclude));
+    Rcpp::traits::input_parameter< std::string& >::type analysis_type(analysis_typeSEXP);
+    rcpp_result_gen = Rcpp::wrap(setgenoTest_bgenDosage(filename, index_filename, ranges_to_include, ranges_to_exclude, ids_to_include, ids_to_exclude, analysis_type));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1545,7 +1546,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_SAIGE_getCrossprodMatAndKin_mailman", (DL_FUNC) &_SAIGE_getCrossprodMatAndKin_mailman, 1},
     {"_SAIGE_get_GRMdiagVec", (DL_FUNC) &_SAIGE_get_GRMdiagVec, 0},
     {"_SAIGE_setminMAFforGRM", (DL_FUNC) &_SAIGE_setminMAFforGRM, 1},
-    {"_SAIGE_setgenoTest_bgenDosage", (DL_FUNC) &_SAIGE_setgenoTest_bgenDosage, 6},
+    {"_SAIGE_setgenoTest_bgenDosage", (DL_FUNC) &_SAIGE_setgenoTest_bgenDosage, 7},
     {"_SAIGE_getDosage_inner_bgen_withquery", (DL_FUNC) &_SAIGE_getDosage_inner_bgen_withquery, 0},
     {"_SAIGE_getDosage_inner_bgen_withquery_new", (DL_FUNC) &_SAIGE_getDosage_inner_bgen_withquery_new, 0},
     {"_SAIGE_getDosage_bgen_withquery", (DL_FUNC) &_SAIGE_getDosage_bgen_withquery, 0},

--- a/src/SAIGE_readDosage_bgen.cpp
+++ b/src/SAIGE_readDosage_bgen.cpp
@@ -29,6 +29,9 @@ namespace {
 
 std::auto_ptr< std::istream > gm_stream;
 
+// 0 for additive, 1 for recessive, 2 for dominant
+int dosage_type;
+
 uint32_t  gm_offset ;
 genfile::bgen::Context gm_context ;
 bool gm_have_sample_ids ;
@@ -141,10 +144,22 @@ int setgenoTest_bgenDosage(std::string & filename,
 	Rcpp::DataFrame & ranges_to_include,
 	Rcpp::DataFrame & ranges_to_exclude,
 	std::vector< std::string > const& ids_to_include,
-	std::vector< std::string > const& ids_to_exclude
+        std::vector< std::string > const& ids_to_exclude,
+        std::string & analysis_type
 ){
 
-   //bgenMinMAF = bgenMinMaf;
+    if (analysis_type == "recessive") {
+        dosage_type = 1;
+        std::cout << "running recessive analysis" << std::endl;
+    } else if (analysis_type == "dominant") {
+        dosage_type = 2;
+        std::cout << "running dominant analysis" << std::endl;
+    } else {
+        dosage_type = 0;
+        std::cout << "running additive analysis" << std::endl;
+    }
+
+  //bgenMinMAF = bgenMinMaf;
    //bgenMinINFO = bgenMinInfo;
    int numMarkers;
    {
@@ -452,7 +467,7 @@ double  Parse(unsigned char * buf, size_t bufLen,  std::string & snpName, uint N
       lut[i] = i/255.0;
 
     double sum_eij = 0, sum_fij_minus_eij2 = 0, sum_eij_sub = 0, sum_fij_minus_eij2_sub = 0; // for INFO
-    double p11,p10,dosage,eij,fij, eijsub, fijsub;
+    double p11,p10,p00,dosage,eij,fij, eijsub, fijsub;
     dosages.clear();
     dosages.reserve(gmtest_samplesize);
     dosages.resize(gmtest_samplesize);
@@ -461,16 +476,23 @@ double  Parse(unsigned char * buf, size_t bufLen,  std::string & snpName, uint N
    for (uint i = 0; i < N; i++) {
       p11 = lut[*bufAt]; bufAt++;
       p10 = lut[*bufAt]; bufAt++;
-      dosage = 2*p11 + p10;
-
+      p00 = 1 - p11 - p10;
+      if (dosage_type == 0) {
+	dosage = p10+p00*2;
+      } else if (dosage_type == 1) {
+        dosage = p00*2;
+      } else if (dosage_type == 2 ) {
+        dosage = p10+p00;
+      }
+      
       if(!missingIdxVec[i]){
-        eij = dosage;
-        fij = 4*p11 + p10;
+        eij = p10+p00*2;
+        fij = 4*p00 + p10;
         sum_eij += eij;
         sum_fij_minus_eij2 += fij - eij*eij;
         if(gm_sample_idx[i] >= 0){
-          dosages[gm_sample_idx[i]] = 2 - dosage;
-	  sum_eij_sub += eij;
+          dosages[gm_sample_idx[i]] = dosage;
+	  sum_eij_sub += dosage;
         }
      }else{
         if(gm_sample_idx[i] >= 0){        
@@ -482,8 +504,7 @@ double  Parse(unsigned char * buf, size_t bufLen,  std::string & snpName, uint N
     //std::cout << "i: " <<  i << std::endl;
     }
 
-
-     AC = 2* ((double) (gmtest_samplesize - missing_cnt)) - sum_eij_sub;
+     AC = sum_eij_sub;
      AF = AC/ 2/ ((double) (gmtest_samplesize - missing_cnt)) ;
 
 
@@ -492,6 +513,7 @@ double  Parse(unsigned char * buf, size_t bufLen,  std::string & snpName, uint N
      1 - sum_fij_minus_eij2 / (2*N*thetaHat*(1-thetaHat));
 
      if(missing_cnt > 0){
+       std::cout << missing_cnt << ' samples missing' << std::endl;
        double imputeDosage = 2*AF;
        for (unsigned int i = 0; i < indexforMissing.size(); i++)
        {


### PR DESCRIPTION
Can give analysisType option in step 2 (additive [default], recessive, or dominant). Only affects the analysis when using bgens and doing so without query. Recessive analysis is true recessive, dosage = 2 * GP(hom_alt). Dominant dosage = GP(het) + GP(hom_alt)