### PR TITLE
Update default R repository for extdata/install_packages.R to cloud.r-project.org

### DIFF
--- a/extdata/install_packages.R
+++ b/extdata/install_packages.R
@@ -3,8 +3,7 @@
 
 req_packages <- c("R.utils", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "MetaSKAT", "SKAT", "roxygen2", "rversions","devtools")
 for (pack in req_packages) {
-    if(!require(pack,character.only = TRUE)) {
-        install.packages(pack, repos = "http://cran.us.r-project.org")
+    if(!require(pack, character.only = TRUE)) {
+        install.packages(pack, repos = "https://cloud.r-project.org")
     }
 }
-


### PR DESCRIPTION
Update default R repository from cran.us.r-project.org to cloud.r-project.org
This is a better choice for default repository for users worldwide due to:
"Automatic redirection to servers worldwide, currently sponsored by Rstudio"
See https://cran.r-project.org/mirrors.html for more information.