### PR TITLE
Allow to use external savvy headers

### DIFF
--- a/src/SAIGE_GENE_readDosageMatrix_vcf.cpp
+++ b/src/SAIGE_GENE_readDosageMatrix_vcf.cpp
@@ -1,6 +1,6 @@
-#include "../thirdParty/cget/include/savvy/reader.hpp"
-#include "../thirdParty/cget/include/savvy/region.hpp"
-#include "../thirdParty/cget/include/savvy/variant_group_iterator.hpp"
+#include "savvy/reader.hpp"
+#include "savvy/region.hpp"
+#include "savvy/variant_group_iterator.hpp"
 
 #include <iostream>
 #include <fstream>

--- a/src/SAIGE_readDosage_vcf.cpp
+++ b/src/SAIGE_readDosage_vcf.cpp
@@ -1,6 +1,6 @@
-#include "../thirdParty/cget/include/savvy/reader.hpp"
-#include "../thirdParty/cget/include/savvy/varint.hpp"
-#include "../thirdParty/cget/include/savvy/sav_reader.hpp"
+#include "savvy/reader.hpp"
+#include "savvy/varint.hpp"
+#include "savvy/sav_reader.hpp"
 
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
This change removes static references to savvy header files.

Compilation of affected files will default to
`../thirdParty/cget/include` but will also allow to use savvy libraries
provided by, for example, external modules.