### PR TITLE
external headers should not use path relative to code

### DIFF
--- a/src/SAIGE_readDosage_bgen.cpp
+++ b/src/SAIGE_readDosage_bgen.cpp
@@ -3,9 +3,9 @@
 #include <cassert>
 #include <stdexcept>
 #include <memory>
-#include "../thirdParty/bgen/genfile/include/genfile/bgen/bgen.hpp"
-#include "../thirdParty/bgen/genfile/include/genfile/bgen/View.hpp"
-#include "../thirdParty/bgen/genfile/include/genfile/bgen/IndexQuery.hpp"
+#include "genfile/bgen/bgen.hpp"
+#include "genfile/bgen/View.hpp"
+#include "genfile/bgen/IndexQuery.hpp"
 #include <sstream>
 #include <time.h>
 #include <Rcpp.h>


### PR DESCRIPTION
external headers should not use path relative to code if include path is used - https://github.com/weizhouUMICH/SAIGE/blob/2c4032a62330b0dc10b56880f38af84ee50727a3/src/Makevars#L4

Relates to: https://github.com/weizhouUMICH/SAIGE/issues/272 
and also: https://github.com/weizhouUMICH/SAIGE/pull/204