### PR TITLE
do not run configure when installing within conda build

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# If installing within conda build ignore configure
+[[ ! -z "$CONDA_BUILD" ]] && exit 0
+
 if [[ -z "$(which cget)" ]]; then
   (>&2 echo "cget must be installed to build SAIGE. Run `pip install cget`.")
   exit 1


### PR DESCRIPTION
https://github.com/weizhouUMICH/SAIGE/issues/272

conda build already provides dependencies, and extra libs should not be overwritten therefore no configure