### PR TITLE
Add `MetaSKAT` to `Remotes`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ License: GPL (>= 2)
 Imports: Rcpp (>= 0.12.12), RcppParallel, Matrix
 LinkingTo: Rcpp, RcppArmadillo, RcppParallel, data.table, SPAtest (== 3.1.2),
         RcppEigen, Matrix, methods, BH, optparse, SKAT, MetaSKAT
+Remotes: github::leeshawn/MetaSKAT        
 SystemRequirements: GNU make
 RoxygenNote: 7.1.1
 NeedsCompilation: yes


### PR DESCRIPTION
With this change it should be possible to simply `remotes::install_github("weizhouUMICH/SAIGE")` until `MetaSKAT` is back on CRAN