### PR TITLE
Limit BLAS thread usage in Step2, fixing a repeatedly reported problem with resource usage.

### DIFF
--- a/extdata/install_packages.R
+++ b/extdata/install_packages.R
@@ -2,7 +2,7 @@
 #install required R packages, from Finnge/SAIGE-IT
 
 #req_packages <- c("R.utils", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "MetaSKAT", "roxygen2", "rversions","devtools", "SKAT")
-req_packages <- c("R.utils", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "roxygen2", "rversions","devtools", "SKAT")
+req_packages <- c("R.utils", "Rcpp", "RcppParallel", "RcppArmadillo", "data.table", "RcppEigen", "Matrix", "methods", "BH", "optparse", "SPAtest", "roxygen2", "rversions","devtools", "SKAT", "RhpcBLASctl")
 for (pack in req_packages) {
     if(!require(pack, character.only = TRUE)) {
         install.packages(pack, repos = "https://cloud.r-project.org")


### PR DESCRIPTION
Some BLAS implementations will attempt to use as many threads as there are logical processors for BLAS operations even where that is not optimal. This change uses the library [RhpcBLASctl](https://cran.r-project.org/web/packages/RhpcBLASctl/index.html) to set the number of threads that BLAS will use to 1 before running Step2, and then reset it back to the value it was originally set to after the step has completed.

This PR updates install_packages.R to indicate that RhpcBLASctl, but doesn't update the Conda package or the Docker image, as I'm not entirely sure how they are installing dependencies. RhpcBLASctl is available from conda-forge, so I expect it could be easily added there.

This will solve the root cause of several reported user issues, including:
https://github.com/weizhouUMICH/SAIGE/issues/380
https://github.com/weizhouUMICH/SAIGE/issues/313
https://github.com/weizhouUMICH/SAIGE/issues/341
https://github.com/weizhouUMICH/SAIGE/issues/102